### PR TITLE
fix printing of disparate marker list

### DIFF
--- a/R/GatingSetToCOMPASS.R
+++ b/R/GatingSetToCOMPASS.R
@@ -167,7 +167,7 @@ COMPASSContainerFromGatingSet<-function(gs = NULL, node = NULL, filter.fun = NUL
       if (warnflag) {
         warning("Not all markers are shared across files.")
         message("Disparate markers are:")
-        message(gettextf("%s "), setdiff(unyn, common))
+        message(gettextf("%s ", setdiff(unyn, common)))
       }
     }
     


### PR DESCRIPTION
gettextf() needs to enclose the set of markers, since message takes a single condition.
Relates to the error Daryl noted.