### PR TITLE
fixed a plot.COMPASSResult() bug that doesn't reorder heatmap

### DIFF
--- a/R/plotMeanGamma.R
+++ b/R/plotMeanGamma.R
@@ -181,6 +181,13 @@ plot.COMPASSResult <- function(x, y, subset=NULL,
 
   ## Construct the base of the 'rowann' data.frame -- annotates rows
   rowann <- data.frame(.id=rownames(M))
+  
+  ## the merge() below expects the COMPASS metadata x$data$meta to be a data.frame
+  
+  if (is(x$data$meta, "data.table")) {
+    x$data$meta <- as.data.frame(x$data$meta)
+  }
+      
   rowann <- merge(
     rowann,
     x$data$meta[c(x$data$individual_id, row_annotation)],


### PR DESCRIPTION
plot.COMPASSResult() merges row_annotation with the COMPASSResult's metadata, which will fail if the metadata is a data.table instead of the expected data.frame. This fix coerces metadata to data.frame to make the plot call work, though there should probably be warnings to the user, if we decide that metadata must be a data.frame.