### PR TITLE
fix COMPASSContainer data order and error message

### DIFF
--- a/R/COMPASSContainer.R
+++ b/R/COMPASSContainer.R
@@ -11,7 +11,7 @@
 ##'   intensity information from an intracellular cytokine experiment.
 ##'   Each element of the list should be named; this name denotes which
 ##'   sample the cell intensities were measured from.
-##' @param counts A named integer vector of the cell counts(of the parent population) for each
+##' @param counts A named integer vector of the cell counts (of the parent population) for each
 ##'   sample in \code{data}.
 ##' @param meta A \code{data.frame} of metadata, describing the individuals
 ##'   in the experiment. Each row in \code{meta} should correspond to a row
@@ -144,7 +144,11 @@ COMPASSContainer <- function(data, counts, meta,
   }
 
   .check_has_names(data, counts)
-  
+
+  # We know that data and counts have the same names.
+  # Now re-order the items in data so that they match the order in counts.
+  data <- data[names(counts)]
+
   if(countFilterThreshold > 0){
     message("Filtering low counts")
     filter <- counts > countFilterThreshold
@@ -153,13 +157,13 @@ COMPASSContainer <- function(data, counts, meta,
     counts <- counts[keep.names]
     meta <- subset(meta, eval(as.name(sample_id)) %in% keep.names)
     message(gettextf("Filtering %s samples due to low counts", length(filter) -
-                length(keep.names)))  
+                length(keep.names)))
   }
-  
-  
+
+
   ## ensure that the counts are >= the number of rows in the data
   if (any(sapply(data, nrow) > counts)) {
-    stop("There are entries in 'counts' that are greater than the ",
+    stop("There are entries in 'counts' that are less than the ",
          "number of rows included in the 'data' matrices.", call.=FALSE)
   }
 


### PR DESCRIPTION
[Line 161](https://github.com/RGLab/COMPASS/blob/0b3a1e5c785ee159f04e9172c345a2c34f95c1b5/R/COMPASSContainer.R#L161) of the `COMPASSContainer()` function checks if any of the data matrices have `nrow` greater than counts, but the error message states that `"There are entries in 'counts' that are` **greater** `than the number of rows included in the 'data' matrices."`. I think it should say `less` instead of `greater`.

(I got this error message and was slightly confused, so I decided to fix it)

Edit:
I discovered the reason why I got the error in the first place. It can occur if the items in `data` and `counts` are in different orders. This commit now includes a line in `COMPASSContainer()` which places the `data` items in the same order as the `counts` list.