### PR TITLE
fix plotCOMPASSResultStack bug in R 4.0

### DIFF
--- a/R/plotMeanGammaMulti.R
+++ b/R/plotMeanGammaMulti.R
@@ -129,7 +129,7 @@ mergeMatricesForPlotCOMPASSResultStack <- function(x,
   catsMerged <- catsMerged[order(catsMerged$Counts),]
   # Make all columns a factor, except for `name`
   catsMergedRowNamesTmp <- catsMerged$name
-  catsMerged <- as.data.frame(sapply(catsMerged, as.factor))
+  catsMerged <- as.data.frame(sapply(catsMerged, as.factor), stringsAsFactors=TRUE)
   catsMerged$name <- catsMergedRowNamesTmp # not a factor
   rownames(catsMerged) <- catsMerged$name
 


### PR DESCRIPTION
`as.data.frame`'s `stringsAsFactors` argument is `TRUE` by default in R 3.x, but `FALSE` in R 4.0. This was causing `plotCOMPASSResultStack` to fail when using R 4.0.