### PR TITLE
accomodate cytoset and remove NA rows from categories matrix

### DIFF
--- a/R/COMPASS.R
+++ b/R/COMPASS.R
@@ -269,6 +269,8 @@ COMPASS <- function(data, treatment, control, subset=NULL,
     .generate_categories <- function(data) {
         ## i'm sorry
         tmp <- unique( as.data.table( lapply( lapply( as.data.table( do.call( rbind, data ) ), as.logical ), as.integer ) ) )
+        # Remove any rows containing NA
+        tmp <- na.omit(tmp)
         tmp[, c("Counts") := apply(.SD, 1, sum)]
         setkeyv(tmp, c("Counts", rev(names(tmp))))
         output <- as.matrix(tmp)

--- a/R/GatingSetToCOMPASS.R
+++ b/R/GatingSetToCOMPASS.R
@@ -135,6 +135,9 @@ COMPASSContainerFromGatingSet<-function(gs = NULL, node = NULL, filter.fun = NUL
       if (inherits(xx, "GatingSetList")) {
         mlist <- unlist( recursive=FALSE, lapply(xx@data, function(x) {
           dat <- flowWorkspace::gs_pop_get_data(x)
+          if (inherits(dat, "cytoset")) {
+            dat <- flowWorkspace::cytoset_to_flowSet(dat)
+          }
           lapply( objects(dat@frames), function(obj) {
             fr <- get(obj, envir=dat@frames)
             return(na.omit( flowCore::parameters(fr)@data$desc ))
@@ -142,6 +145,9 @@ COMPASSContainerFromGatingSet<-function(gs = NULL, node = NULL, filter.fun = NUL
         }) )
       } else if (inherits(xx, "GatingSet")) {
         dat <- flowWorkspace::gs_pop_get_data(xx)
+        if (inherits(dat, "cytoset")) {
+          dat <- flowWorkspace::cytoset_to_flowSet(dat)
+        }
         mlist <- lapply( objects(dat@frames), function(obj) {
           fr <- get(obj, envir=dat@frames)
           return(na.omit( flowCore::parameters(fr)@data$desc ))


### PR DESCRIPTION
- Converts `cytoset` to `flowSet` when extracting data in  `COMPASSContainerFromGatingSet()`
- For some reason `NA` categories were getting generated for my data. I added a line to omit these rows during category generation in `COMPASS()`